### PR TITLE
First iteration of arm pose message format

### DIFF
--- a/autonomy/wato_msgs/common_msgs/CMakeLists.txt
+++ b/autonomy/wato_msgs/common_msgs/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.10)
+project(common_msgs)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+
+set(msg_files
+    msg/ArmPose.msg
+    msg/HandPose.msg
+    msg/JointState.msg
+    )
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+    ${msg_files}
+    DEPENDENCIES std_msgs geometry_msgs
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+ament_package()

--- a/autonomy/wato_msgs/common_msgs/msg/ArmPose.msg
+++ b/autonomy/wato_msgs/common_msgs/msg/ArmPose.msg
@@ -1,0 +1,11 @@
+std_msgs/Header header
+
+string name
+
+common_msgs/JointState shoulder
+common_msgs/JointState elbow
+common_msgs/JointState wrist
+
+# Optional Overall Hand Pose
+bool include_hand_pose
+common_msgs/HandPose hand_pose

--- a/autonomy/wato_msgs/common_msgs/msg/HandPose.msg
+++ b/autonomy/wato_msgs/common_msgs/msg/HandPose.msg
@@ -1,0 +1,28 @@
+std_msgs/Header header
+
+string name
+
+# Thumb
+common_msgs/JointState thumb_cmc
+common_msgs/JointState thumb_mcp
+common_msgs/JointState thumb_ip
+
+# Index
+common_msgs/JointState index_mcp
+common_msgs/JointState index_pip
+common_msgs/JointState index_dip
+
+# Middle
+common_msgs/JointState middle_mcp
+common_msgs/JointState middle_pip
+common_msgs/JointState middle_dip
+
+# Ring
+common_msgs/JointState ring_mcp
+common_msgs/JointState ring_pip
+common_msgs/JointState ring_dip
+
+# Pinky
+common_msgs/JointState pinky_mcp
+common_msgs/JointState pinky_pip
+common_msgs/JointState pinky_dip

--- a/autonomy/wato_msgs/common_msgs/msg/JointState.msg
+++ b/autonomy/wato_msgs/common_msgs/msg/JointState.msg
@@ -1,0 +1,9 @@
+std_msgs/Header header
+
+string name
+
+float64[] position  
+float64[] velocity
+float64[] effort
+
+geometry_msgs/Quaternion orientation

--- a/autonomy/wato_msgs/common_msgs/package.xml
+++ b/autonomy/wato_msgs/common_msgs/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>common_msgs</name>
+  <version>0.0.0</version>there was
+  <description>Common ROS2 message definitions for the WATO Humanoid project.</description>
+
+  <maintainer email="gavintranquilino@gmail.com">Gavin Tranquilino</maintainer>
+  <license>Apache2.0</license> 
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
New ROS message definitions to the `common_msgs` package:

*   `ArmPose.msg`: Describes the state of an arm, including its major joints and optionally the hand.
*   `HandPose.msg`: Details the state of a hand, including individual finger joint states.
*   `JointState.msg`: A custom message (similar message structure to [sensor_msgs/JointState](https://docs.ros.org/en/humble/p/sensor_msgs/msg/JointState.html)) to represent a single joint
