### PR TITLE
disable-lint-ci-for-sim

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,2 @@
+# Isaac Sim / RL simulation code — excluded from CI clang-format
+autonomy/simulation/**

--- a/.github/workflows/linting_auto.yml
+++ b/.github/workflows/linting_auto.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           auto_fix: ${{ contains(github.event.pull_request.labels.*.name, 'auto-lint') }}
           Autopep8: true
-          Autopep8_args: "--max-line-length 100"
+          Autopep8_args: "--max-line-length 100 --exclude '*autonomy/simulation*'"
           clang_format: true
           clang_format_auto_fix: ${{ contains(github.event.pull_request.labels.*.name, 'auto-lint') }}
           clang_format_args: "-style=file"

--- a/docker/behaviour/joint_command/joint_command.Dockerfile
+++ b/docker/behaviour/joint_command/joint_command.Dockerfile
@@ -3,7 +3,6 @@ ARG BASE_IMAGE=ghcr.io/watonomous/robot_base/base:humble-ubuntu22.04
 ################################ Source ################################
 FROM ${BASE_IMAGE} AS source
 
-ARG AMENT_WS=/root/ament_ws
 WORKDIR ${AMENT_WS}/src
 
 COPY autonomy/behaviour/joint_command joint_command

--- a/docker/samples/cpp_aggregator.Dockerfile
+++ b/docker/samples/cpp_aggregator.Dockerfile
@@ -12,7 +12,7 @@ COPY autonomy/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | { grep 'apt-get install' || true; } \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/samples/cpp_producer.Dockerfile
+++ b/docker/samples/cpp_producer.Dockerfile
@@ -12,7 +12,7 @@ COPY autonomy/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | { grep 'apt-get install' || true; } \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/samples/cpp_transformer.Dockerfile
+++ b/docker/samples/cpp_transformer.Dockerfile
@@ -12,7 +12,7 @@ COPY autonomy/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | { grep 'apt-get install' || true; } \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/samples/py_aggregator.Dockerfile
+++ b/docker/samples/py_aggregator.Dockerfile
@@ -12,7 +12,7 @@ COPY autonomy/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | { grep 'apt-get install' || true; } \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/samples/py_producer.Dockerfile
+++ b/docker/samples/py_producer.Dockerfile
@@ -12,7 +12,7 @@ COPY autonomy/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | { grep 'apt-get install' || true; } \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/samples/py_transformer.Dockerfile
+++ b/docker/samples/py_transformer.Dockerfile
@@ -12,7 +12,7 @@ COPY autonomy/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | { grep 'apt-get install' || true; } \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/docker/simulation/isaac_sim/isaac_sim.Dockerfile
+++ b/docker/simulation/isaac_sim/isaac_sim.Dockerfile
@@ -12,7 +12,7 @@ COPY autonomy/wato_msgs/sample_msgs sample_msgs
 # Scan for rosdeps
 RUN apt-get -qq update && rosdep update && \
     rosdep install --from-paths . --ignore-src -r -s \
-        | grep 'apt-get install' \
+        | { grep 'apt-get install' || true; } \
         | awk '{print $3}' \
         | sort  > /tmp/colcon_install_list
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+# Monorepo lint settings (CI: .github/workflows/linting_auto.yml)
+[pycodestyle]
+max-line-length = 100
+exclude = *autonomy/simulation*
+
+[pep8]
+max-line-length = 100
+exclude = *autonomy/simulation*


### PR DESCRIPTION
Disable Reason:
- Isaaclab need to initialize AppLauncher() before import other isaacsim related stuff, if anyone run a lint fix, it will break it 