### PR TITLE
Streamline IL: unify sim episode control, simplify create_dataset

### DIFF
--- a/autonomy/il/humanoid_il/schema.py
+++ b/autonomy/il/humanoid_il/schema.py
@@ -7,8 +7,6 @@ from typing import Any
 
 import yaml
 
-from humanoid_il.record_utils import get_next_experiment_path_with_gap
-
 
 def load_yaml(path: Path) -> dict[str, Any]:
     with path.open(encoding="utf-8") as f:
@@ -58,13 +56,8 @@ def build_features(cfg: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return features
 
 
-def create_dataset(
-    cfg: dict[str, Any],
-    *,
-    record_root: Path | None = None,
-    experiment_path: Path | None = None,
-):
-    """Create a new LeRobotDataset on disk."""
+def create_dataset(cfg: dict[str, Any], *, root: Path):
+    """Create a new LeRobotDataset on disk under the given root."""
     try:
         from lerobot.datasets.lerobot_dataset import LeRobotDataset
     except ImportError as exc:
@@ -73,15 +66,9 @@ def create_dataset(
             "pip install -e 'autonomy/il[lerobot]'"
         ) from exc
 
+    root.mkdir(parents=True, exist_ok=True)
     record_cfg = cfg.get("record") or {}
-    if experiment_path is not None:
-        root = experiment_path
-        root.mkdir(parents=True, exist_ok=True)
-    else:
-        root_base = Path(record_root or record_cfg.get("root", "datasets/record"))
-        root = get_next_experiment_path_with_gap(root_base)
-
-    dataset = LeRobotDataset.create(
+    return LeRobotDataset.create(
         repo_id=str(cfg.get("repo_id", "humanoid/local")),
         fps=int(cfg.get("fps", 30)),
         root=root,
@@ -90,4 +77,3 @@ def create_dataset(
         image_writer_processes=int(record_cfg.get("image_writer_processes", 0)),
         features=build_features(cfg),
     )
-    return dataset, root

--- a/autonomy/il/humanoid_il/sim_recorder.py
+++ b/autonomy/il/humanoid_il/sim_recorder.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 import queue
 import subprocess
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import torch
 from tqdm import tqdm
+
+from humanoid_il.episode_keys import EpisodeFlags, EpisodeKeyboard
 
 
 class SimLeRobotRecorder:
@@ -75,6 +78,48 @@ class SimLeRobotRecorder:
             target=self._async_processor, daemon=True
         )
         self._processor_thread.start()
+
+        self._flags: EpisodeFlags | None = None
+        self._keyboard: EpisodeKeyboard | None = None
+        self._last_frame_t: float = 0.0
+        self._frame_period: float = 1.0 / fps
+
+    def start_keyboard(self) -> bool:
+        """Create episode flags, attach keyboard listener, and return whether keyboard started."""
+        self._flags = EpisodeFlags(start=False)
+        self._keyboard = EpisodeKeyboard(self._flags)
+        return self._keyboard.start()
+
+    def tick(
+        self,
+        action: np.ndarray | torch.Tensor,
+        state: np.ndarray | torch.Tensor,
+        images: dict[str, np.ndarray | torch.Tensor],
+        depth_buffers: dict[str, np.ndarray | torch.Tensor] | None = None,
+        instance_id_seg_buffers: dict[str, np.ndarray | torch.Tensor] | None = None,
+    ) -> bool:
+        """Handle episode flags and push one frame if the rate allows.
+
+        Returns True if an episode was just saved (so callers can trigger a scene reset).
+        No-op if start_keyboard() was never called.
+        """
+        if self._flags is None:
+            return False
+        flags = self._flags
+        if flags.remove:
+            self.cancel_recording()
+            flags.remove = False
+        if flags.success:
+            self.save_episode()
+            flags.success = False
+            flags.start = False
+            return True
+        if flags.start:
+            now = time.monotonic()
+            if now - self._last_frame_t >= self._frame_period:
+                self._last_frame_t = now
+                self.push_frame_to_buffer(action, state, images, depth_buffers, instance_id_seg_buffers)
+        return False
 
     @property
     def is_complete(self) -> bool:
@@ -288,6 +333,9 @@ class SimLeRobotRecorder:
 
     def finalize(self) -> None:
         """Block until all queued episodes are saved, then stop the worker thread."""
+        if self._keyboard is not None:
+            self._keyboard.stop()
+            self._keyboard = None
         self._episode_queue.join()
         self._stop_event.set()
         self._processor_thread.join(timeout=5.0)

--- a/autonomy/il/humanoid_il/sinks/lerobot.py
+++ b/autonomy/il/humanoid_il/sinks/lerobot.py
@@ -13,7 +13,8 @@ from humanoid_il.snapshot import ObservationSnapshot
 class LeRobotSink:
     def __init__(self, cfg: dict[str, Any], *, root: Path) -> None:
         self._image_keys = list(enabled_images(cfg).keys())
-        self._dataset, self._root = create_dataset(cfg, experiment_path=root)
+        self._root = root
+        self._dataset = create_dataset(cfg, root=root)
 
     @property
     def name(self) -> str:

--- a/autonomy/simulation/Teleop/keyboard-based teleoperation/keyboard_teleop.py
+++ b/autonomy/simulation/Teleop/keyboard-based teleoperation/keyboard_teleop.py
@@ -193,16 +193,10 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
     sim_dt = sim.get_physics_dt()
     recorder, record_cfg = _init_recorder(sim.device)
 
-    import time
     import numpy as np
-    from humanoid_il.episode_keys import EpisodeFlags, EpisodeKeyboard
 
-    flags = EpisodeFlags(start=False)
-    keyboard = EpisodeKeyboard(flags)
     if recorder is not None:
-        keyboard.start()
-    _last_frame_t = 0.0
-    _frame_period = 1.0 / (record_cfg.get("fps", 30) if record_cfg else 30)
+        recorder.start_keyboard()
 
     # Ensure robot buffers are populated before reading limits / joint names
     scene.update(sim_dt)
@@ -306,20 +300,9 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
         robot.set_joint_position_target(joint_pos_des, joint_ids=left_arm_ids)
 
         if recorder is not None:
-            if flags.remove:
-                recorder.cancel_recording()
-                flags.remove = False
-            if flags.success:
-                recorder.save_episode()
-                flags.success = False
-                flags.start = False
-            if flags.start:
-                now = time.monotonic()
-                if now - _last_frame_t >= _frame_period:
-                    _last_frame_t = now
-                    state = joint_pos[0].detach().cpu().numpy().astype(np.float32)
-                    action = joint_pos_des[0].detach().cpu().numpy().astype(np.float32)
-                    recorder.push_frame_to_buffer(action, state, {})
+            state = joint_pos[0].detach().cpu().numpy().astype(np.float32)
+            action = joint_pos_des[0].detach().cpu().numpy().astype(np.float32)
+            recorder.tick(action, state, {})
 
         # Hold gripper fingers at synchronized open/closed pair (one GL40 motor on hardware).
         # High stiffness in cfg + zero velocity target prevents bounce when the arm moves.
@@ -340,7 +323,6 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
         scene.update(sim_dt)
 
     if recorder is not None:
-        keyboard.stop()
         recorder.finalize()
         print(f"[RECORD] Saved under {recorder.dataset_root}")
 

--- a/autonomy/simulation/Teleop/so101-leader teleoperation/so101_keyboard_teleop.py
+++ b/autonomy/simulation/Teleop/so101-leader teleoperation/so101_keyboard_teleop.py
@@ -215,15 +215,8 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
 
     recorder, record_cfg = _init_recorder(sim.device)
 
-    import time
-    from humanoid_il.episode_keys import EpisodeFlags, EpisodeKeyboard
-
-    flags = EpisodeFlags(start=False)
-    keyboard = EpisodeKeyboard(flags)
     if recorder is not None:
-        keyboard.start()
-    _last_frame_t = 0.0
-    _frame_period = 1.0 / (record_cfg.get("fps", 30) if record_cfg else 30)
+        recorder.start_keyboard()
 
     gripper_open = torch.tensor([[GRIPPER_OPEN]], device=sim.device)
     gripper_closed = torch.tensor([[GRIPPER_CLOSED]], device=sim.device)
@@ -275,34 +268,19 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
         robot.set_joint_position_target(gripper_target, joint_ids=[gripper_joint_id])
 
         if recorder is not None:
-            if flags.remove:
-                recorder.cancel_recording()
-                flags.remove = False
-            if flags.success:
-                recorder.save_episode()
-                flags.success = False
-                flags.start = False
-                if not recorder.is_complete:
-                    maybe_apply_domain_rand(scene, args_cli)
-            if flags.start:
-                now = time.monotonic()
-                if now - _last_frame_t >= _frame_period:
-                    _last_frame_t = now
-                    state_rad = robot.data.joint_pos[0, all_joint_ids].detach().cpu().numpy()
-                    action_rad = torch.cat(
-                        [arm_joint_des[0], gripper_target[0]], dim=0
-                    ).detach().cpu().numpy()
-                    state_raw = sim_rad_to_leader_raw(state_rad)
-                    action_raw = sim_rad_to_leader_raw(action_rad)
-                    images = capture_record_images(scene, record_cfg) or {}
-                    recorder.push_frame_to_buffer(action_raw, state_raw, images)
+            state_rad = robot.data.joint_pos[0, all_joint_ids].detach().cpu().numpy()
+            action_rad = torch.cat([arm_joint_des[0], gripper_target[0]], dim=0).detach().cpu().numpy()
+            state_raw = sim_rad_to_leader_raw(state_rad)
+            action_raw = sim_rad_to_leader_raw(action_rad)
+            images = capture_record_images(scene, record_cfg) or {}
+            if recorder.tick(action_raw, state_raw, images) and not recorder.is_complete:
+                maybe_apply_domain_rand(scene, args_cli)
 
         scene.write_data_to_sim()
         sim.step()
         scene.update(sim_dt)
 
     if recorder is not None:
-        keyboard.stop()
         recorder.finalize()
         print(f"[RECORD] Saved under {recorder.dataset_root}")
 

--- a/autonomy/simulation/Teleop/so101-leader teleoperation/so101_leader_teleop.py
+++ b/autonomy/simulation/Teleop/so101-leader teleoperation/so101_leader_teleop.py
@@ -204,15 +204,8 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
     leader = _connect_leader(args_cli.port, args_cli.robot_id, args_cli.recalibrate)
     recorder, record_cfg = _init_recorder(sim.device)
 
-    import time
-    from humanoid_il.episode_keys import EpisodeFlags, EpisodeKeyboard
-
-    flags = EpisodeFlags(start=False)
-    keyboard = EpisodeKeyboard(flags)
     if recorder is not None:
-        keyboard.start()
-    _last_frame_t = 0.0
-    _frame_period = 1.0 / (record_cfg.get("fps", 30) if record_cfg else 30)
+        recorder.start_keyboard()
 
     should_reset = False
     last_leader_raw = None
@@ -260,30 +253,17 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
         robot.set_joint_position_target(target, joint_ids=joint_ids)
 
         if recorder is not None:
-            if flags.remove:
-                recorder.cancel_recording()
-                flags.remove = False
-            if flags.success:
-                recorder.save_episode()
-                flags.success = False
-                flags.start = False
-                if not recorder.is_complete:
-                    maybe_apply_domain_rand(scene, args_cli)
-            if flags.start:
-                now = time.monotonic()
-                if now - _last_frame_t >= _frame_period:
-                    _last_frame_t = now
-                    measured = robot.data.joint_pos[0, joint_ids].detach().cpu().numpy()
-                    state_raw = sim_rad_to_leader_raw(measured)
-                    images = capture_record_images(scene, record_cfg) or {}
-                    recorder.push_frame_to_buffer(leader_raw.copy(), state_raw, images)
+            measured = robot.data.joint_pos[0, joint_ids].detach().cpu().numpy()
+            state_raw = sim_rad_to_leader_raw(measured)
+            images = capture_record_images(scene, record_cfg) or {}
+            if recorder.tick(leader_raw.copy(), state_raw, images) and not recorder.is_complete:
+                maybe_apply_domain_rand(scene, args_cli)
 
         scene.write_data_to_sim()
         sim.step()
         scene.update(sim_dt)
 
     if recorder is not None:
-        keyboard.stop()
         recorder.finalize()
         print(f"[RECORD] Saved under {recorder.dataset_root}")
 


### PR DESCRIPTION
- SimLeRobotRecorder gains start_keyboard() and tick() methods so the episode flags/keyboard/rate-limiting loop is owned by the recorder rather than duplicated across every teleop script. finalize() now stops the keyboard listener automatically.
- All three teleop scripts (keyboard_teleop, so101_keyboard_teleop, so101_leader_teleop) drop ~15 lines each of flag-handling boilerplate; the per-step block reduces to recorder.tick(action, state, images).
- create_dataset() simplified to a single required root: Path parameter; the dead record_root branch and get_next_experiment_path_with_gap import are removed from schema.py. LeRobotSink updated to match.

https://claude.ai/code/session_01NFYSHfEmqNn7d75qCnzAEy